### PR TITLE
feature: enable to load partial model

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -348,10 +348,10 @@ def io_match_acception(n, env_args, num_agents, port):
 
 
 def get_model(env, model_path):
-    import torch
     from model import DuelingNet as Model
+    from model import load_model
     model = env.net()(env) if hasattr(env, 'net') else Model(env)
-    model.load_state_dict(torch.load(model_path))
+    model = load_model(model, model_path)
     model.eval()
     return model
 

--- a/model.py
+++ b/model.py
@@ -14,11 +14,7 @@ from util import map_r
 
 
 def load_model(model, model_path):
-    loaded_dict_ = torch.load(model_path)
-    model_dict = model.state_dict()
-    loaded_dict = {k: v for k, v in loaded_dict_.items() if k in model_dict}
-    model_dict.update(loaded_dict)
-    model.load_state_dict(model_dict)
+    model.load_state_dict(torch.load(model_path), strict=False)
     return model
 
 

--- a/model.py
+++ b/model.py
@@ -13,6 +13,15 @@ import torch.nn.functional as F
 from util import map_r
 
 
+def load_model(model, model_path):
+    loaded_dict_ = torch.load(model_path)
+    model_dict = model.state_dict()
+    loaded_dict = {k: v for k, v in loaded_dict_.items() if k in model_dict}
+    model_dict.update(loaded_dict)
+    model.load_state_dict(model_dict)
+    return model
+
+
 def to_torch(x, transpose=False, unsqueeze=None):
     if x is None:
         return None

--- a/train.py
+++ b/train.py
@@ -28,7 +28,7 @@ import torch.optim as optim
 
 import environment as gym
 from util import map_r, bimap_r, trimap_r, rotate, type_r
-from model import to_torch, to_gpu_or_not, RandomModel
+from model import load_model, to_torch, to_gpu_or_not, RandomModel
 from model import DuelingNet as Model
 from connection import MultiProcessWorkers, MultiThreadWorkers
 from connection import accept_socket_connections
@@ -570,7 +570,7 @@ class Learner:
                         else:
                             try:
                                 model = self.model_class(self.env, self.args)
-                                model.load_state_dict(torch.load(self.model_path(model_id)))
+                                model = load_model(model, self.model_path(model_id))
                             except:
                                 # return latest model if failed to load specified model
                                 pass


### PR DESCRIPTION
To train additional
- targets
- rewards
- inputs and network components,

add load_model function that enables us to load partial models.