### PR TITLE
fix: set current model as 'model' first when loading old model

### DIFF
--- a/handyrl/train.py
+++ b/handyrl/train.py
@@ -671,9 +671,8 @@ class Learner:
 
                 elif req == 'model':
                     for model_id in data:
-                        if model_id == self.model_era:
-                            model = self.model
-                        else:
+                        model = self.model
+                        if model_id != self.model_era:
                             try:
                                 model = self.model_class(self.env, self.args)
                                 model.load_state_dict(torch.load(self.model_path(model_id)), strict=False)


### PR DESCRIPTION
bigfix