### PR TITLE
(Idea) feature: set original state as action in Geister

### DIFF
--- a/handyrl/environments/geister.py
+++ b/handyrl/environments/geister.py
@@ -321,8 +321,8 @@ class Environment(BaseEnvironment):
 
     def legal(self, action):
         if self.turn_count < 0:
-            action = action - 4 * 6 * 6 - 70 * self.color
-            return 0 <= action and action < 70
+            layout = action - 4 * 6 * 6 - 70 * self.color
+            return 0 <= layout < 70
 
         pos_from = self.action2from(action, self.color)
         pos_to = self.action2to(action, self.color)


### PR DESCRIPTION
Each player can set first piece positions in the original geister game.
But there is a problem;
original positions will be deterministically chosen by Agent.action().
Therefore, evaluating models with zero temperature may be unsuitable.