### PR TITLE
fix: stop calling reset() in the construtor of BaseEnvironment

### DIFF
--- a/handyrl/environment.py
+++ b/handyrl/environment.py
@@ -34,7 +34,7 @@ def make_env(env_args):
 
 class BaseEnvironment:
     def __init__(self, args={}):
-        self.reset()
+        pass
 
     def __str__(self):
         return ''


### PR DESCRIPTION
Calling overridden reset() function before setting each environment is clearly bad procedure.