### PR TITLE
(Idea) change entropy regularization coefficient from 0.3 -> 0.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ train_args:
     forward_steps: 16
     compress_steps: 4
     lambda: 0.7
-    entropy_regularization: 3.0e-1
+    entropy_regularization: 1.0e-1
     entropy_regularization_decay: 0.1
     update_episodes: 2000
     batch_size: 128


### PR DESCRIPTION
With value 0.3, training of TicTacToe on local machine looks too slow.