### PR TITLE
(Idea) select only one player to train in observation mode

### DIFF
--- a/handyrl/train.py
+++ b/handyrl/train.py
@@ -55,6 +55,8 @@ def make_batch(episodes, args):
         moments_ = sum([pickle.loads(bz2.decompress(ms)) for ms in ep['moment']], [])
         moments = moments_[ep['start'] - ep['base']:ep['end'] - ep['base']]
         players = list(moments[0]['observation'].keys())
+        if args['observation']:
+            players = [random.choice(players)]  # choose 1 player in observation mode
 
         obs_zeros = map_r(moments[0]['observation'][moments[0]['turn']], lambda o: np.zeros_like(o))  # template for padding
         if args['observation']:


### PR DESCRIPTION
In current code, batch shape of N-player game with observation is (B, T, N, ...) and it can be too big.
Selecting one player is good default configuration for general use cases.

Do we need configuration column to switch this setting?