### PR TITLE
fix: calling multiprocessing.Pipe

### DIFF
--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -119,7 +119,7 @@ def open_multiprocessing_connections(num_process, target, args_func):
     # open connections
     s_conns, g_conns = [], []
     for _ in range(num_process):
-        conn0, conn1 = mp.connection.Pipe(duplex=True)
+        conn0, conn1 = mp.Pipe(duplex=True)
         s_conns.append(conn0)
         g_conns.append(conn1)
 

--- a/handyrl/worker.py
+++ b/handyrl/worker.py
@@ -181,7 +181,7 @@ class Workers(QueueCommunicator):
         else:
             # open local connections
             for i in range(self.args['worker']['num_gather']):
-                conn0, conn1 = mp.connection.Pipe(duplex=True)
+                conn0, conn1 = mp.Pipe(duplex=True)
                 mp.Process(target=gather_loop, args=(self.args, conn1, i)).start()
                 conn1.close()
                 self.add(conn0)


### PR DESCRIPTION
multiprocessing.connection.Pipe() -> multiprocessing.Pipe()

https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Pipe