### PR TITLE
fix: random model outputs p, v with dtype=np.float32

### DIFF
--- a/handyrl/model.py
+++ b/handyrl/model.py
@@ -237,7 +237,7 @@ class BaseModel(nn.Module):
 
 class RandomModel(BaseModel):
     def inference(self, x=None, hidden=None):
-        return {'policy': np.zeros(self.action_length), 'value': np.zeros(1)}
+        return {'policy': np.zeros(self.action_length, dtype=np.float32), 'value': np.zeros(1, dtype=np.float32)}
 
 
 class SimpleConv2DModel(BaseModel):


### PR DESCRIPTION
We should be more careful after using from_numpy().