### PR TITLE
(WIP) feature: set OMP_NUM_THREADS=1 and ulimit -n 8192 in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,16 @@
 # Copyright (c) 2020 DeNA Co., Ltd.
 # Licensed under The MIT License [see LICENSE for details]
 
+import os
+import resource
 import sys
 import yaml
 
 
 if __name__ == '__main__':
+    os.environ['OMP_NUM_THREADS'] = '1'
+    resource.setrlimit(resource.RLIMIT_NOFILE, (8192, resource.RLIM_INFINITY))
+
     with open('config.yaml') as f:
         args = yaml.safe_load(f)
     print(args)


### PR DESCRIPTION
65536 was not worked in MacBookPro.
Is there any way to know hard limit?