### PR TITLE
fix: handle ConnectionResetError when sending data

### DIFF
--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -244,6 +244,8 @@ class QueueCommunicator:
                 continue
             try:
                 conn.send(send_data)
+            except ConnectionResetError:
+                self.disconnect(conn)
             except BrokenPipeError:
                 self.disconnect(conn)
 


### PR DESCRIPTION
It seems a bug but it rarely caused an error in small scale experiments.