### PR TITLE
Fix a typo in a parameter name

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,8 +25,8 @@ train_args:
     worker:
         num_parallel: 6
     lambda: 0.7
-    policy_target: 'TD' # 'UGPO' 'VTRACE' 'TD' 'MC'
-    value_target: 'TD' # 'VTRACE' 'TD' 'MC'
+    policy_target: 'TD' # 'UPGO' 'VTRACE' 'TD' 'MC'
+    value_target: 'TD' # 'UPGO' 'VTRACE' 'TD' 'MC'
     seed: 0
     restart_epoch: 0
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -64,13 +64,13 @@ This parameters are used for training (`python main.py --train`, `python main.py
     * `MC`, monte carlo
     * `TD`, TD(λ)
     * `VTRACE`, [V-Trace described in IMPALA paper](https://arxiv.org/abs/1802.01561)
-    * `UGPO`, [UPGO described in AlphaStar paper](https://www.nature.com/articles/s41586-019-1724-z)
+    * `UPGO`, [UPGO described in AlphaStar paper](https://www.nature.com/articles/s41586-019-1724-z)
 * `value_target`, type = enum
     * value target for value loss
     * `MC`, monte carlo
     * `TD`, TD(λ)
     * `VTRACE`, [V-Trace described in IMPALA paper](https://arxiv.org/abs/1802.01561)
-    * `UGPO`, [UPGO described in AlphaStar paper](https://www.nature.com/articles/s41586-019-1724-z)
+    * `UPGO`, [UPGO described in AlphaStar paper](https://www.nature.com/articles/s41586-019-1724-z)
 * `seed`, type = int
     * used to set seed in learner and actor
     * **NOTE** this seed cannot guarantee the reproducibility for now


### PR DESCRIPTION
You mention `UGPO` as a parameter in documentation, but there is no such name. 
Besides, documentation says that `UGPO` can be used in `value_target`, while it was not mentioned in the config.yaml.