### PR TITLE
Fix: `unable to open shared memory object` error in multiprocessing

### DIFF
--- a/handyrl/train.py
+++ b/handyrl/train.py
@@ -590,7 +590,7 @@ class Learner:
                             except:
                                 # return latest model if failed to load specified model
                                 pass
-                        send_data.append(model)
+                        send_data.append(pickle.dumps(model))
 
                 if not multi_req and len(send_data) == 1:
                     send_data = send_data[0]

--- a/handyrl/worker.py
+++ b/handyrl/worker.py
@@ -10,6 +10,7 @@ import functools
 from socket import gethostname
 from collections import deque
 import multiprocessing as mp
+import pickle
 
 from .environment import prepare_env, make_env
 from .connection import QueueCommunicator
@@ -47,7 +48,7 @@ class Worker:
                     model_pool[model_id] = self.latest_model[1]
                 else:
                     # get model from server
-                    model_pool[model_id] = send_recv(self.conn, ('model', model_id))
+                    model_pool[model_id] = pickle.loads(send_recv(self.conn, ('model', model_id)))
                     # update latest model
                     if model_id > self.latest_model[0]:
                         self.latest_model = model_id, model_pool[model_id]


### PR DESCRIPTION
Pickle PyTorch model before sending data