### PR TITLE
feature: change buffer_size of Batcher from 3 to 1

### DIFF
--- a/handyrl/train.py
+++ b/handyrl/train.py
@@ -265,7 +265,7 @@ class Batcher:
 
         self.executor = MultiProcessJobExecutor(
             self._worker, self._selector(), self.args['num_batchers'],
-            buffer_length=3, num_receivers=2
+            buffer_length=1, num_receivers=2
         )
 
     def _selector(self):


### PR DESCRIPTION
Since the number of Batchers should be large enough, buffer_size=1 is usually OK.