### PR TITLE
chore: remove unsafe -=

### DIFF
--- a/handyrl/agent.py
+++ b/handyrl/agent.py
@@ -61,7 +61,7 @@ class Agent:
         v = outputs.get('value', None)
         mask = np.ones_like(p)
         mask[actions] = 0
-        p -= mask * 1e32
+        p = p - mask * 1e32
 
         if show:
             print_outputs(env, softmax(p), v)


### PR DESCRIPTION
Such substitution sometimes causes terrible situations when we develop something based on HandyRL.