### PR TITLE
(Idea) chore: use simple list for QueueCommunicator.conns

### DIFF
--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -200,8 +200,7 @@ class QueueCommunicator:
     def __init__(self, conns=[]):
         self.input_queue = queue.Queue(maxsize=256)
         self.output_queue = queue.Queue(maxsize=256)
-        self.conns = {}
-        self.conn_index = 0
+        self.conns = []
         for conn in conns:
             self.add_connection(conn)
         self.shutdown_flag = False
@@ -224,12 +223,11 @@ class QueueCommunicator:
         self.output_queue.put((conn, send_data))
 
     def add_connection(self, conn):
-        self.conns[conn] = self.conn_index
-        self.conn_index += 1
+        self.conns.append(conn)
 
     def disconnect(self, conn):
         print('disconnected')
-        self.conns.pop(conn, None)
+        self.conns.remove(conn)
 
     def _send_thread(self):
         while not self.shutdown_flag:


### PR DESCRIPTION
I'd like to remember why we needed conn_index.

If there are more connections, would set() be better?