### PR TITLE
feature: add requirements.txt for scripts/

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+onnxruntime
+matplotlib
+seaborn


### PR DESCRIPTION
I think users enable to know which libraries will be needed after running scripts, but requirements.txt will them.

While `onnxruntime` is actually not necessary for `make_onnx_model.py`, it will help understanding about the usage of the generated ONNX models.