### PR TITLE
fix: remove hidden output from random model

### DIFF
--- a/handyrl/model.py
+++ b/handyrl/model.py
@@ -68,7 +68,7 @@ class RandomModel(nn.Module):
         wrapped_model = ModelWrapper(model)
         hidden = wrapped_model.init_hidden()
         outputs = wrapped_model.inference(x, hidden)
-        self.output_dict = {key: np.zeros_like(value) for key, value in outputs.items()}
+        self.output_dict = {key: np.zeros_like(value) for key, value in outputs.items() if key != 'hidden'}
 
     def inference(self, *args):
         return self.output_dict


### PR DESCRIPTION
Since the shape of hidden outputs is free, we should not apply `np.zeros_like` with hidden outputs.

```
map_r(outputs, lambda o: np.zeros_like(o) if o is not None else None)
```
is more general but currently it might be too abstract.