### PR TITLE
chore: remove fileno() inferface from PickledConnection

### DIFF
--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -29,9 +29,6 @@ class PickledConnection:
             self.conn.close()
             self.conn = None
 
-    def fileno(self):
-        return self.conn.fileno()
-
     def _recv(self, size):
         buf = io.BytesIO()
         while size > 0:


### PR DESCRIPTION
I have never concerned `fineno()` interface. Is it useful?