### PR TITLE
fix: onnx saved model name

### DIFF
--- a/scripts/make_onnx_model.py
+++ b/scripts/make_onnx_model.py
@@ -1,6 +1,7 @@
 
 # Usage: python3 script/make_onnx_model.py MODEL_PATH
 
+import re
 import sys
 import yaml
 import torch
@@ -13,7 +14,7 @@ from handyrl.util import map_r
 
 
 model_path = sys.argv[-1]
-saved_model_path = model_path.rstrip('.pth') + '.onnx'
+saved_model_path = re.sub('\.pth$', '.onnx', model_path)
 
 with open('config.yaml') as f:
     args = yaml.safe_load(f)


### PR DESCRIPTION
I didn't know `rstrip`'s behavior...
```
# Wrong
a = 'models/latest.pth'
a.rstrip('.pth') + .onnx #-> 'models/lates.onnx'
```
```
# Correct
import re
re.sub('\.pth$', '.onnx', a)  #-> 'models/latest.onnx'
```