### PR TITLE
feature: add *.onnx to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.pyc
 *.pth
+*.onnx


### PR DESCRIPTION
We already officially supported saving and loading ONNX models.