### PR TITLE
(Idea) feature: fast worker count config

### DIFF
--- a/handyrl/worker.py
+++ b/handyrl/worker.py
@@ -263,7 +263,11 @@ class RemoteWorkerCluster:
                 p.terminate()
 
 
-def worker_main(args):
+def worker_main(args, argv):
     # offline generation worker
-    worker = RemoteWorkerCluster(args=args['worker_args'])
+    worker_args = args['worker_args']
+    if len(argv) >= 1: 
+        worker_args['num_parallel'] = int(argv[0])
+
+    worker = RemoteWorkerCluster(args=worker_args)
     worker.run()

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         main(args)
     elif mode == '--worker' or mode == '-w':
         from handyrl.worker import worker_main as main
-        main(args)
+        main(args, sys.argv[2:])
     elif mode == '--eval' or mode == '-e':
         from handyrl.evaluation import eval_main as main
         main(args, sys.argv[2:])


### PR DESCRIPTION
This is useful when you want to quickly change just the number of workers, such as when the two machines sharing a disk have different numbers of CPUs, or when you also want to reserve a few workers aside from the training machine.