### PR TITLE
feature: use set instead of list for connections in QueueCommunicator

### DIFF
--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -199,7 +199,7 @@ class QueueCommunicator:
     def __init__(self, conns=[]):
         self.input_queue = queue.Queue(maxsize=256)
         self.output_queue = queue.Queue(maxsize=256)
-        self.conns = []
+        self.conns = set()
         for conn in conns:
             self.add_connection(conn)
         self.shutdown_flag = False
@@ -222,11 +222,11 @@ class QueueCommunicator:
         self.output_queue.put((conn, send_data))
 
     def add_connection(self, conn):
-        self.conns.append(conn)
+        self.conns.add(conn)
 
     def disconnect(self, conn):
         print('disconnected')
-        self.conns.remove(conn)
+        self.conns.discard(conn)
 
     def _send_thread(self):
         while not self.shutdown_flag:


### PR DESCRIPTION
`set.discard(a)` doesn't raise unfound error.