### PR TITLE
feature: connection count interface

### DIFF
--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -180,7 +180,7 @@ class MultiProcessJobExecutor:
                         break
                     except queue.Full:
                         pass
-        print('finished receiver %d' % index)
+        print('finished receiver')
 
 
 class QueueCommunicator:

--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -140,7 +140,7 @@ class MultiProcessJobExecutor:
 
         for i in range(num_workers):
             conn0, conn1 = mp.Pipe(duplex=True)
-            mp.Process(target=func, args=(conn1, i)).start()
+            mp.Process(target=func, args=(conn1, i), daemon=True).start()
             conn1.close()
             self.conns.append(conn0)
             self.waiting_conns.put(conn0)

--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -156,30 +156,20 @@ class MultiProcessJobExecutor:
         print('start sender')
         while True:
             data = next(self.send_generator)
-            while True:
-                try:
-                    conn = self.waiting_conns.get(timeout=0.3)
-                    conn.send(data)
-                    break
-                except queue.Empty:
-                    pass
+            conn = self.waiting_conns.get()
+            conn.send(data)
         print('finished sender')
 
     def _receiver(self):
         print('start receiver')
         while True:
-            tmp_conns = connection.wait(self.conns)
-            for conn in tmp_conns:
+            conns = connection.wait(self.conns)
+            for conn in conns:
                 data = conn.recv()
                 self.waiting_conns.put(conn)
                 if self.postprocess is not None:
                     data = self.postprocess(data)
-                while True:
-                    try:
-                        self.output_queue.put(data, timeout=0.3)
-                        break
-                    except queue.Full:
-                        pass
+                self.output_queue.put(data)
         print('finished receiver')
 
 
@@ -208,10 +198,7 @@ class QueueCommunicator:
 
     def _send_thread(self):
         while True:
-            try:
-                conn, send_data = self.output_queue.get(timeout=0.3)
-            except queue.Empty:
-                continue
+            conn, send_data = self.output_queue.get()
             try:
                 conn.send(send_data)
             except ConnectionResetError:
@@ -231,9 +218,4 @@ class QueueCommunicator:
                 except EOFError:
                     self.disconnect(conn)
                     continue
-                while True:
-                    try:
-                        self.input_queue.put((conn, recv_data), timeout=0.3)
-                        break
-                    except queue.Full:
-                        pass
+                self.input_queue.put((conn, recv_data))

--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -183,6 +183,9 @@ class QueueCommunicator:
         threading.Thread(target=self._send_thread, daemon=True).start()
         threading.Thread(target=self._recv_thread, daemon=True).start()
 
+    def connection_count(self):
+        return len(self.conns)
+
     def recv(self, timeout=None):
         return self.input_queue.get(timeout=timeout)
 

--- a/handyrl/train.py
+++ b/handyrl/train.py
@@ -535,7 +535,7 @@ class Learner:
         # no update call before storing minimum number of episodes + 1 epoch
         next_update_episodes = prev_update_episodes + self.args['update_episodes']
 
-        while len(self.worker.conns) > 0 or not self.shutdown_flag:
+        while self.worker.connection_count() > 0 or not self.shutdown_flag:
             try:
                 conn, (req, data) = self.worker.recv(timeout=0.3)
             except queue.Empty:

--- a/handyrl/train.py
+++ b/handyrl/train.py
@@ -535,7 +535,7 @@ class Learner:
         # no update call before storing minimum number of episodes + 1 epoch
         next_update_episodes = prev_update_episodes + self.args['update_episodes']
 
-        while len(self.worker.conns) > 0:
+        while len(self.worker.conns) > 0 or not self.shutdown_flag:
             try:
                 conn, (req, data) = self.worker.recv(timeout=0.3)
             except queue.Empty:

--- a/handyrl/worker.py
+++ b/handyrl/worker.py
@@ -128,7 +128,7 @@ class Gather(QueueCommunicator):
         print('finished gather %d' % self.gather_id)
 
     def run(self):
-        while len(self.conns) > 0:
+        while self.connection_count() > 0:
             try:
                 conn, (command, args) = self.recv(timeout=0.3)
             except queue.Empty:


### PR DESCRIPTION
After #307 , we can add `connection_count()` interface to prevent direct access to `conns`.