### PR TITLE
fix: stop calling view_transition() in reset phase

### DIFF
--- a/handyrl/evaluation.py
+++ b/handyrl/evaluation.py
@@ -58,7 +58,8 @@ class NetworkAgentClient:
                     reset = args[1]
                     if reset:
                         self.agent.reset(self.env, show=True)
-                    view_transition(self.env)
+                    else:
+                        view_transition(self.env)
             self.conn.send(ret)
 
 


### PR DESCRIPTION
This is simply a bug.