### PR TITLE
chore: add kwargs to random model

### DIFF
--- a/handyrl/model.py
+++ b/handyrl/model.py
@@ -70,5 +70,5 @@ class RandomModel(nn.Module):
         outputs = wrapped_model.inference(x, hidden)
         self.output_dict = {key: np.zeros_like(value) for key, value in outputs.items() if key != 'hidden'}
 
-    def inference(self, *args):
+    def inference(self, *args, **kwargs):
         return self.output_dict


### PR DESCRIPTION
When we call `inference()` with some keyword arguments, RandomModel should accept them.