### PR TITLE
(Idea) feature: proportional accept rate during all phases

### DIFF
--- a/handyrl/train.py
+++ b/handyrl/train.py
@@ -288,7 +288,7 @@ class Batcher:
         while True:
             ep_count = min(len(self.episodes), self.args['maximum_episodes'])
             ep_idx = random.randrange(ep_count)
-            accept_rate = 1 - (ep_count - 1 - ep_idx) / self.args['maximum_episodes']
+            accept_rate = 1 - (ep_count - 1 - ep_idx) / ep_count
             if random.random() < accept_rate:
                 break
         ep = self.episodes[ep_idx]


### PR DESCRIPTION
So far, the adoption rate in the replay buffer has been linear based on `maximum_episodes`, but this means that the earliest episodes will be selected many times before the buffer is filled.

Even if the diversity in each batch will be decreased a little, it would be better to use a weight proportional to the number of current episodes so that the earliest episodes are less likely to be selected.