### PR TITLE
fix: remove map_location=cpu error after starting training

### DIFF
--- a/handyrl/train.py
+++ b/handyrl/train.py
@@ -432,7 +432,7 @@ class Learner:
         self.worker = WorkerServer(args) if remote else WorkerCluster(args)
 
         # thread connection
-        self.trainer = Trainer(args, self.model)
+        self.trainer = Trainer(args, copy.deepcopy(self.model))
 
     def model_path(self, model_id):
         return os.path.join('models', str(model_id) + '.pth')


### PR DESCRIPTION
```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```

After the training started in the 0th generation, when the worker was reconnected, the above error occurred because Learner's self.model was on the GPU.