### PR TITLE
feature: remove installation of kaggle environments from github actions

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -24,7 +24,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install -r handyrl/envs/kaggle/requirements.txt
       - name: pytest
         run: |
           python -m pytest tests

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -8,7 +8,7 @@ ENVS = [
     'tictactoe',
     'geister',
     'parallel_tictactoe',
-    'kaggle.hungry_geese',
+    # 'kaggle.hungry_geese',
 ]
 
 


### PR DESCRIPTION
Is checking kaggle-environments in github tests necessary?