### PR TITLE
Revert "chore: remove fileno() inferface from PickledConnection"

### DIFF
--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -29,6 +29,9 @@ class PickledConnection:
             self.conn.close()
             self.conn = None
 
+    def fileno(self):
+        return self.conn.fileno()
+
     def _recv(self, size):
         buf = io.BytesIO()
         while size > 0:


### PR DESCRIPTION
This reverts commit 31b8fb9b486ee6db93bef125da8197fcb1e328d1.