### PR TITLE
fix: disconnect after socket.timeout

### DIFF
--- a/handyrl/connection.py
+++ b/handyrl/connection.py
@@ -201,6 +201,8 @@ class QueueCommunicator:
             conn, send_data = self.output_queue.get()
             try:
                 conn.send(send_data)
+            except TimeoutError:
+                self.disconnect(conn)
             except ConnectionResetError:
                 self.disconnect(conn)
             except BrokenPipeError:
@@ -212,6 +214,9 @@ class QueueCommunicator:
             for conn in conns:
                 try:
                     recv_data = conn.recv()
+                except TimeoutError:
+                    self.disconnect(conn)
+                    continue
                 except ConnectionResetError:
                     self.disconnect(conn)
                     continue


### PR DESCRIPTION
When the socket.timeout occurs, new worker connections are not accepted.